### PR TITLE
LWC Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,10 @@
             <id>sonatype</id>
             <url>https://oss.sonatype.org/content/groups/public/</url>
         </repository>
+        <repository>
+            <id>codemc-repo</id>
+            <url>https://repo.codemc.io/repository/maven-public/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -69,6 +73,12 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.13.2-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.griefcraft</groupId>
+            <artifactId>lwc</artifactId>
+            <version>2.2.9-dev</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/net/simple/armor/stand/pose/ArmorStandPose.java
+++ b/src/main/java/net/simple/armor/stand/pose/ArmorStandPose.java
@@ -1,5 +1,7 @@
 package net.simple.armor.stand.pose;
 
+import java.util.UUID;
+import net.simple.armor.stand.pose.hooks.LWCXHook;
 import net.simple.armor.stand.pose.listeners.ArmorPose;
 import net.simple.armor.stand.pose.listeners.ArmorSpawn;
 import net.simple.armor.stand.pose.utils.ArmorSetPose;
@@ -12,7 +14,7 @@ import java.io.File;
 import java.util.HashMap;
 
 public final class ArmorStandPose extends JavaPlugin {
-    private final HashMap<Location, Integer> armorPose = new HashMap<>();
+    private final HashMap<UUID, Integer> armorPose = new HashMap<>();
 
     @Override
     public void onEnable() {
@@ -28,6 +30,10 @@ public final class ArmorStandPose extends JavaPlugin {
 
         Bukkit.getPluginManager().registerEvents(new ArmorPose(armorPose, armorSetPose, config), this); // ArmorStand Poses
         Bukkit.getPluginManager().registerEvents(new ArmorSpawn(armorPose, armorSetPose), this); // ArmorStand Spawn change pose
+
+        if (Bukkit.getPluginManager().getPlugin("LWC") != null) {
+            new LWCXHook(this);
+        }
 
         getLogger().info("Started up!");
     }

--- a/src/main/java/net/simple/armor/stand/pose/events/ArmorStandPoseChangeEvent.java
+++ b/src/main/java/net/simple/armor/stand/pose/events/ArmorStandPoseChangeEvent.java
@@ -1,0 +1,55 @@
+package net.simple.armor.stand.pose.events;
+
+import net.simple.armor.stand.pose.listeners.ArmorPose;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class ArmorStandPoseChangeEvent extends Event implements Cancellable {
+
+  private static final HandlerList HANDLERS = new HandlerList();
+
+  private boolean cancelled = false;
+  private final ArmorStand armorStand;
+  private final Player player;
+  private final int pose;
+
+  public ArmorStandPoseChangeEvent(ArmorStand armorStand, Player player, int pose) {
+    this.armorStand = armorStand;
+    this.player = player;
+    this.pose = pose;
+  }
+
+  public static HandlerList getHandlerList() {
+    return HANDLERS;
+  }
+
+  public ArmorStand getArmorStand() {
+    return armorStand;
+  }
+
+  public Player getPlayer() {
+    return player;
+  }
+
+  public int getPose() {
+    return pose;
+  }
+
+  @Override
+  public HandlerList getHandlers() {
+    return HANDLERS;
+  }
+
+  @Override
+  public boolean isCancelled() {
+    return cancelled;
+  }
+
+  @Override
+  public void setCancelled(boolean cancelled) {
+    this.cancelled = cancelled;
+  }
+}

--- a/src/main/java/net/simple/armor/stand/pose/hooks/LWCXHook.java
+++ b/src/main/java/net/simple/armor/stand/pose/hooks/LWCXHook.java
@@ -1,0 +1,30 @@
+package net.simple.armor.stand.pose.hooks;
+
+import com.griefcraft.bukkit.EntityBlock;
+import com.griefcraft.lwc.LWC;
+import net.simple.armor.stand.pose.events.ArmorStandPoseChangeEvent;
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class LWCXHook implements Listener {
+
+  private final LWC lwc;
+
+  public LWCXHook(JavaPlugin plugin) {
+    lwc = LWC.getInstance();
+    Bukkit.getPluginManager().registerEvents(this, plugin);
+  }
+
+  @EventHandler
+  public void onSetPose(ArmorStandPoseChangeEvent event) {
+    // read current armorstand as LWC entity block
+    EntityBlock block = new EntityBlock(event.getArmorStand());
+    // check if player is allowed to modify armorstand
+    if (!this.lwc.canAccessProtection(event.getPlayer(), lwc.findProtection(block))) {
+      // if not, do not modify armorstand
+      event.setCancelled(true);
+    }
+  }
+}

--- a/src/main/java/net/simple/armor/stand/pose/listeners/ArmorPose.java
+++ b/src/main/java/net/simple/armor/stand/pose/listeners/ArmorPose.java
@@ -1,76 +1,90 @@
 package net.simple.armor.stand.pose.listeners;
 
+import java.util.UUID;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
+import net.simple.armor.stand.pose.events.ArmorStandPoseChangeEvent;
 import net.simple.armor.stand.pose.utils.ArmorSetPose;
 import net.simple.armor.stand.pose.utils.MainConfig;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractAtEntityEvent;
 
 import java.util.HashMap;
 
 public class ArmorPose implements Listener {
-    private final HashMap<Location, Integer> armorPose;
+    /**
+     * A map of entity UUIDs and their pose index. UUID instead of location so that moving
+     * armorstands are still contained in the mapping.
+     */
+    private final HashMap<UUID, Integer> armorPose;
     private final ArmorSetPose armorSetPose;
     private final MainConfig config;
 
-    public ArmorPose(HashMap<Location, Integer> armorPose, ArmorSetPose armorSetPose, MainConfig config) {
+    public ArmorPose(HashMap<UUID, Integer> armorPose, ArmorSetPose armorSetPose, MainConfig config) {
         this.armorPose = armorPose;
         this.armorSetPose = armorSetPose;
         this.config = config;
     }
 
-    @EventHandler
+    @EventHandler (priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onClick(PlayerInteractAtEntityEvent event) {
         Entity entity = event.getRightClicked();
-        if (entity instanceof ArmorStand) {
-            Player player = event.getPlayer();
+        if (!(entity instanceof ArmorStand)) return;
 
-            if (config.getEnableChangeArmorStandPerm()) {
-                if (!player.hasPermission(config.getChangePosePerm())) {
-                    event.setCancelled(true);
-                    player.sendMessage(config.getNotHavePerm());
-                    return;
-                }
-            }
+        Player player = event.getPlayer();
+        if (!player.isSneaking()) return;
 
-            if (config.getEnableBlacklistWorlds()) {
-                if (config.getBlacklistWorlds().contains(player.getWorld().getName())) {
-                    event.setCancelled(true);
-                    player.sendMessage(config.getDisableInWorld());
-                    return;
-                }
-            }
+        ArmorStand armorStand = (ArmorStand) event.getRightClicked();
 
-            if (!player.isSneaking()) return;
-            event.setCancelled(true);
+        // inform everybody that this plugin is about to change the pose
+        ArmorStandPoseChangeEvent poseEvent = new ArmorStandPoseChangeEvent(armorStand, player, -1);
+        Bukkit.getPluginManager().callEvent(poseEvent);
 
-            ArmorStand armorStand = (ArmorStand) event.getRightClicked();
-            if (armorPose.containsKey(armorStand.getLocation())) {
-                int pose = armorPose.get(armorStand.getLocation());
-                armorPose.remove(armorStand.getLocation());
+        // if any plugin does not want this to happen (like lwcx due to protections) return
+        if (poseEvent.isCancelled()) {
+            return;
+        }
 
-                if (armorSetPose.isLastPose(pose)) {
-                    armorPose.put(armorStand.getLocation(), 1);
-                } else {
-                    armorPose.put(armorStand.getLocation(), pose + 1);
-                }
-                armorSetPose.setPose(armorStand, pose);
+        // all preconditions for cancelling met, cancel actual event
+        event.setCancelled(true);
 
-                if (config.getEnableActionBarPose()) player.spigot()
-                        .sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(config.getActionBarMessage() + pose));
-            } else {
-                armorPose.put(armorStand.getLocation(), 2);
-                armorSetPose.setPose(armorStand, 1);
-
-                if (config.getEnableActionBarPose()) player.spigot()
-                        .sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(config.getActionBarMessage() + 1));
+        if (config.getEnableChangeArmorStandPerm()) {
+            if (!player.hasPermission(config.getChangePosePerm())) {
+                player.sendMessage(config.getNotHavePerm());
+                return;
             }
         }
+
+        if (config.getEnableBlacklistWorlds()) {
+            if (config.getBlacklistWorlds().contains(player.getWorld().getName())) {
+                player.sendMessage(config.getDisableInWorld());
+                return;
+            }
+        }
+
+        int pose = armorPose.compute(armorStand.getUniqueId(), (uuid, index) -> {
+            // not yet contained in mapping
+            if (index == null) {
+                return 2;
+            }
+            // last pose, go back to pose 1
+            if (armorSetPose.isLastPose(index + 1)) {
+                return 1;
+            }
+            // simply increase
+            return index + 1;
+        });
+
+        armorSetPose.setPose(armorStand, pose);
+
+        if (config.getEnableActionBarPose()) player.spigot()
+            .sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(config.getActionBarMessage() + pose));
     }
 }

--- a/src/main/java/net/simple/armor/stand/pose/listeners/ArmorPose.java
+++ b/src/main/java/net/simple/armor/stand/pose/listeners/ArmorPose.java
@@ -50,6 +50,13 @@ public class ArmorPose implements Listener {
             }
         }
 
+        if (config.getEnableBlacklistWorlds()) {
+            if (config.getBlacklistWorlds().contains(player.getWorld().getName())) {
+                player.sendMessage(config.getDisableInWorld());
+                return;
+            }
+        }
+
         // inform everybody that this plugin is about to change the pose
         ArmorStandPoseChangeEvent poseEvent = new ArmorStandPoseChangeEvent(armorStand, player, -1);
         Bukkit.getPluginManager().callEvent(poseEvent);
@@ -61,14 +68,6 @@ public class ArmorPose implements Listener {
 
         // all preconditions for cancelling met, cancel actual event
         event.setCancelled(true);
-
-
-        if (config.getEnableBlacklistWorlds()) {
-            if (config.getBlacklistWorlds().contains(player.getWorld().getName())) {
-                player.sendMessage(config.getDisableInWorld());
-                return;
-            }
-        }
 
         int pose = armorPose.compute(armorStand.getUniqueId(), (uuid, index) -> {
             // not yet contained in mapping

--- a/src/main/java/net/simple/armor/stand/pose/listeners/ArmorPose.java
+++ b/src/main/java/net/simple/armor/stand/pose/listeners/ArmorPose.java
@@ -43,6 +43,13 @@ public class ArmorPose implements Listener {
 
         ArmorStand armorStand = (ArmorStand) event.getRightClicked();
 
+        if (config.getEnableChangeArmorStandPerm()) {
+            if (!player.hasPermission(config.getChangePosePerm())) {
+                player.sendMessage(config.getNotHavePerm());
+                return;
+            }
+        }
+
         // inform everybody that this plugin is about to change the pose
         ArmorStandPoseChangeEvent poseEvent = new ArmorStandPoseChangeEvent(armorStand, player, -1);
         Bukkit.getPluginManager().callEvent(poseEvent);
@@ -55,12 +62,6 @@ public class ArmorPose implements Listener {
         // all preconditions for cancelling met, cancel actual event
         event.setCancelled(true);
 
-        if (config.getEnableChangeArmorStandPerm()) {
-            if (!player.hasPermission(config.getChangePosePerm())) {
-                player.sendMessage(config.getNotHavePerm());
-                return;
-            }
-        }
 
         if (config.getEnableBlacklistWorlds()) {
             if (config.getBlacklistWorlds().contains(player.getWorld().getName())) {

--- a/src/main/java/net/simple/armor/stand/pose/listeners/ArmorPose.java
+++ b/src/main/java/net/simple/armor/stand/pose/listeners/ArmorPose.java
@@ -75,7 +75,7 @@ public class ArmorPose implements Listener {
                 return 2;
             }
             // last pose, go back to pose 1
-            if (armorSetPose.isLastPose(index + 1)) {
+            if (armorSetPose.isLastPose(index)) {
                 return 1;
             }
             // simply increase

--- a/src/main/java/net/simple/armor/stand/pose/listeners/ArmorSpawn.java
+++ b/src/main/java/net/simple/armor/stand/pose/listeners/ArmorSpawn.java
@@ -1,30 +1,32 @@
 package net.simple.armor.stand.pose.listeners;
 
+import java.util.UUID;
 import net.simple.armor.stand.pose.utils.ArmorSetPose;
 import org.bukkit.Location;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntitySpawnEvent;
 
 import java.util.HashMap;
 
 public class ArmorSpawn implements Listener {
-    private final HashMap<Location, Integer> armorPose;
+    private final HashMap<UUID, Integer> armorPose;
     private final ArmorSetPose armorSetPose;
 
-    public ArmorSpawn(HashMap<Location, Integer> armorPose, ArmorSetPose armorSetPose) {
+    public ArmorSpawn(HashMap<UUID, Integer> armorPose, ArmorSetPose armorSetPose) {
         this.armorPose = armorPose;
         this.armorSetPose = armorSetPose;
     }
 
-    @EventHandler
+    @EventHandler (priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onEntitySpawn(EntitySpawnEvent event) {
         Entity entity = event.getEntity();
         if(entity instanceof ArmorStand) {
             ArmorStand armorStand = (ArmorStand) event.getEntity();
-            armorPose.remove(armorStand.getLocation());
+            armorPose.remove(armorStand.getUniqueId());
 
             armorSetPose.setPose(armorStand, 1);
         }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,3 +4,6 @@ main: net.simple.armor.stand.pose.ArmorStandPose
 api-version: 1.13
 authors: [ KessPenGames ]
 description: Plugin for pose armor stand
+
+softdepend:
+  - LWC


### PR DESCRIPTION
Hello!
This pull request adds support for the protection plugin LWC.

Some general changes:
- Events priorities are set to HIGHEST, which tells spigot to handle them when all other plugins (like especially protection plugins) are done and may have cancelled the event already.
- Changed the HashSet from <Location, Integer> to <UUID, Integer>. Every entity has a UUID and with this change, the pose index is mapped to the actual entity and not the location it was. This is important because armorstands could be placed in a water stream or somebody could place an armorstand where 2h ago another armorstand was placed with pose 7. His or her armorstand would start with pose 7
- An event to indicate that the plugin is about to change an armorstand pose. Other plugins can then again cancel the event and tell this plugin to stop changing the pose. This is used in the LWC hook.
- The interact listener first checks if the player is sneaking and only then does permission checks. More intuitive and performance friendly :)

Changes for LWC
- If an armorstand is protected with LWC it cannot be modified by another player. The event that I just mentioned will be cancelled if the player attempts to
- LWC is an optional dependency, the plugin works fine without.